### PR TITLE
Streamline POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
+			<properties>
+				<maven.compiler.source>1.6</maven.compiler.source>
+				<maven.compiler.target>1.6</maven.compiler.target>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -65,20 +69,15 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.1</version>
-						<configuration>
-							<source>1.6</source>
-							<target>1.6</target>
-						</configuration>
-					</plugin>
 				</plugins>
 			</build>
 		</profile>
 		<profile>
 			<id>java-8</id>
+			<properties>
+				<maven.compiler.source>1.8</maven.compiler.source>
+				<maven.compiler.target>1.8</maven.compiler.target>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -99,15 +98,6 @@
 								</configuration>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.1</version>
-						<configuration>
-							<source>1.8</source>
-							<target>1.8</target>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,12 @@
 
 	<name>codecentric allocation tracker</name>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.6</version>
-				<configuration>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -76,7 +72,6 @@
 						<configuration>
 							<source>1.6</source>
 							<target>1.6</target>
-							<encoding>UTF-8</encoding>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -112,7 +107,6 @@
 						<configuration>
 							<source>1.8</source>
 							<target>1.8</target>
-							<encoding>UTF-8</encoding>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Most work done with complete `<plugin>` definitions in the Maven POM can be solved by using simple properties, e. g. project global encoding doesn't need to be configured per-plugin.
