### PR TITLE
Use TimeUnit for sleeping for better readability

### DIFF
--- a/src/main/java/de/codecentric/performance/agent/allocation/AllocationProfilingAgent.java
+++ b/src/main/java/de/codecentric/performance/agent/allocation/AllocationProfilingAgent.java
@@ -4,6 +4,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.instrument.Instrumentation;
 import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -47,7 +48,7 @@ public class AllocationProfilingAgent {
               AgentLogger.log("Could not register Agent MBean in 10 minutes.");
               return;
             }
-            Thread.sleep(10000l);
+            TimeUnit.SECONDS.sleep(10);
             mbs = ManagementFactory.getPlatformMBeanServer();
           }
           mbs.registerMBean(new Agent(), new ObjectName("de.codecentric:type=Agent"));


### PR DESCRIPTION
The `Thread.sleep(long)` method takes the time to sleep as milliseconds. This is not good for readability, since one has to translate milliseconds into the seconds for example.

The TimeUnit enum provides a nice solution for this. Internally it will translate the passed in value to milliseconds and call `Thread.sleep(long)` so no changes to the current behavior are to be expected.
