### PR TITLE
Add basic test for the AllocationTrackerClassFileTransformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,24 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
 			<version>5.0.3</version>

--- a/src/test/java/de/codecentric/performance/agent/allocation/AllocationTrackerClassFileTransformerTest.java
+++ b/src/test/java/de/codecentric/performance/agent/allocation/AllocationTrackerClassFileTransformerTest.java
@@ -1,0 +1,63 @@
+package de.codecentric.performance.agent.allocation;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.codecentric.test.TestBean;
+
+public class AllocationTrackerClassFileTransformerTest {
+
+  /**
+   * The object under test
+   */
+  private AllocationTrackerClassFileTransformer transformer;
+
+  @Before
+  public void setUp() {
+    transformer = new AllocationTrackerClassFileTransformer("de.codecentric.test");
+  }
+
+  @Test
+  public void allocationTrackerClassesAreIgnored() throws Exception {
+    byte[] classBytes = getClassBytes(ConstructorVisitor.class);
+    byte[] actual = transformer.transform(null, ConstructorVisitor.class.getName(), ConstructorVisitor.class, null,
+        classBytes);
+
+    assertSame(classBytes, actual);
+  }
+
+  @Test
+  public void notMatchingClassPrefixesAreIgnored() throws Exception {
+    byte[] classBytes = getClassBytes(Assert.class);
+    byte[] actual = transformer.transform(null, Assert.class.getName(), Assert.class, null, classBytes);
+
+    assertSame(classBytes, actual);
+  }
+
+  @Test
+  public void matchingClassesAreExtended() throws Exception {
+    byte[] byteArray = getClassBytes(TestBean.class);
+    byte[] actual = transformer.transform(null, TestBean.class.getName(), TestBean.class, null, byteArray);
+
+    // the class has been changed. What else can we do?
+    assertThat(actual.length, is(greaterThan(byteArray.length)));
+  }
+
+  private byte[] getClassBytes(Class<?> clazz) throws IOException {
+    String className = clazz.getName();
+    String classAsPath = className.replace('.', '/') + ".class";
+    InputStream stream = clazz.getClassLoader().getResourceAsStream(classAsPath);
+    
+    return IOUtils.toByteArray(stream);
+  }
+}

--- a/src/test/java/de/codecentric/test/TestBean.java
+++ b/src/test/java/de/codecentric/test/TestBean.java
@@ -1,0 +1,8 @@
+package de.codecentric.test;
+
+/**
+ * Test class for testing byte code manipulation
+ */
+public class TestBean {
+
+}


### PR DESCRIPTION
This PR adds a very basic test for the `AllocationTrackerClassFileTransformer`. It checks
- whether classes from the tracker packer are ignored
- whether classes with the wrong prefix are ignored
- whether the byte representation of classes are changed by the transformer
